### PR TITLE
Added code to handle .bz2 archives.

### DIFF
--- a/basket/main.py
+++ b/basket/main.py
@@ -98,12 +98,20 @@ class Basket(object):
         """Open the ``requires.txt`` file from the given TAR-gzipped
         archive.
         """
-        with tarfile.open(path, 'r:gz') as archive:
-            for info in archive:
-                if info.name.endswith(
-                    os.path.join('.egg-info', 'requires.txt')):
-                    return archive.extractfile(info).readlines()
-        return ()
+        extension = os.path.splitext(path)[1]
+        if extension == '.gz': 
+            with tarfile.open(path, 'r:gz') as archive:
+                for info in archive:
+                    if info.name.endswith(
+                        os.path.join('.egg-info', 'requires.txt')):
+                        return archive.extractfile(info).readlines()                    
+        elif extension == '.bz2':
+            with tarfile.open(path, 'r:bz2') as archive:
+                for info in archive:
+                    if info.name.endswith(
+                        os.path.join('.egg-info', 'requires.txt')):
+                        return archive.extractfile(info).readlines()            
+        return ()  
 
     def _open_req_in_zip_archive(self, path):
         """Open the ``requires.txt`` file from the given zipped


### PR DESCRIPTION
I came across an issue while basket was downloading pytz.  pytz is a
bz2 archive.  Basket tested to see if the archive was a type that
tarfile could extract, which bz2 is, however in the extraction function
only .gz was being handled.  I simply extracted the extension and then
used an if statement to change which archive format tarfile was
extracting.  Probably can be done a bit more efficient but I'm flying
out in a few moments and wanted to get it uploaded.
