### PR TITLE
Handle versions in requirements.

### DIFF
--- a/basket/main.py
+++ b/basket/main.py
@@ -84,6 +84,7 @@ class Basket(object):
         we return the latest one.
         """
         query = query.lower()
+        query = query.split()[0]
         candidates = []
         for info in self.client.search({'name': query}):
             if info['name'].lower() == query:


### PR DESCRIPTION
This change allows Basket to handle packages that require specific versions of other packages. For example, take a look at [flake8](https://pypi.python.org/pypi/flake8). Its dependencies (as of 2015-04-05) are:
- mccabe (>=0.2.1,<0.4)
- pep8 (>=1.5.7,<1.6)
- pyflakes (>=0.8.1,<0.9)

Adding flake8 to a basket will succeed, but when it comes to downloading dependencies they will not be pulled because Basket will query PyPI with the package name _and_ the version information. Obviously this will fail because there is not  package on PyPI named `mccabe (>=0.2.1,<0.4)`. This change will split up the query string by spaces and only search PyPI for the first part of the string (`mccabe`).

This change does not download the specific versions required by the package. The existence of the `basket purge` command makes it pretty clear to me that Basket by design is only interested in the latest versions of packages.
