### PR TITLE
Update PYPI_ENDPOINT to use https

### DIFF
--- a/basket/main.py
+++ b/basket/main.py
@@ -9,7 +9,7 @@ from basket.compat import xmlrpclib
 from basket.compat import text
 
 
-PYPI_ENDPOINT = 'http://pypi.python.org/pypi'
+PYPI_ENDPOINT = 'https://pypi.python.org/pypi'
 
 
 def get_package_name(line):


### PR DESCRIPTION
Using http seems to cause a ProtocolError

```
xmlrpclib.ProtocolError: <ProtocolError for pypi.python.org/pypi: 403 Must access using HTTPS instead of HTTP>
```

Changing the endpoint to https:// instead of http:// seems to work. Possibly the PyPI website has been changed to allow https requests only.
